### PR TITLE
Error handling in OWIN middleware

### DIFF
--- a/ProblemDetails.WebApi/Owin/ProblemDetailsMiddleware.cs
+++ b/ProblemDetails.WebApi/Owin/ProblemDetailsMiddleware.cs
@@ -87,7 +87,7 @@ namespace IntelligentPlant.ProblemDetails.Owin {
                     await WriteProblemDetailsToStream(problemDetails, response, responseBodyStream).ConfigureAwait(false);
                 }
                 catch (Exception e) {
-                    var errorDetails = _options.ExceptionHandler?.Invoke(e, ProblemDetailsFactory.Default);
+                    var errorDetails = _options.ExceptionHandler?.Invoke(context, e, ProblemDetailsFactory.Default);
                     if (errorDetails == null) {
                         // No problem details provided; rethrow the exception.
                         throw;

--- a/ProblemDetails.WebApi/Owin/ProblemDetailsMiddlewareOptions.cs
+++ b/ProblemDetails.WebApi/Owin/ProblemDetailsMiddlewareOptions.cs
@@ -27,7 +27,7 @@ namespace IntelligentPlant.ProblemDetails.Owin {
         /// for an unhandled exception in the OWIN pipeline. Return <see langword="null"/> to 
         /// rethrow the unhandled exception.
         /// </summary>
-        public Func<Exception, ProblemDetailsFactory, ProblemDetails?>? ExceptionHandler { get; set; }
+        public Func<IOwinContext, Exception, ProblemDetailsFactory, ProblemDetails?>? ExceptionHandler { get; set; }
 
     }
 }

--- a/ProblemDetails.WebApi/Owin/ProblemDetailsMiddlewareOptions.cs
+++ b/ProblemDetails.WebApi/Owin/ProblemDetailsMiddlewareOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.Owin;
 
@@ -20,6 +21,13 @@ namespace IntelligentPlant.ProblemDetails.Owin {
         /// matches an <see cref="IncludePaths"/> entry and be excluded via an entry here.
         /// </summary>
         public IEnumerable<PathString>? ExcludePaths { get; set; }
+
+        /// <summary>
+        /// A delegate that can be used to generate a custom <see cref="ProblemDetails"/> object 
+        /// for an unhandled exception in the OWIN pipeline. Return <see langword="null"/> to 
+        /// rethrow the unhandled exception.
+        /// </summary>
+        public Func<Exception, ProblemDetailsFactory, ProblemDetails?>? ExceptionHandler { get; set; }
 
     }
 }

--- a/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
+++ b/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/intelligentplant/ProblemDetails.WebApi</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <Choose>

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ private static ProblemDetails? ProblemDetailsErrorHandler(IOwinContext context, 
         return factory.CreateProblemDetails(context, 403);
     }
 
+    // Return null to rethrow the unhandled exception.
     return null;
 }
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ public void Configuration(IAppBuilder app) {
 ```
 
 
-## Manually Creating Problem Details Responses
+## Manually Creating Problem Details Responses in API Controllers
 
 The `IntelligentPlant.ProblemDetails.WebApi` namespace contains extension methods for the `ApiController` type to allow direct creation of responses containing problem details objects in API controller methods, allowing you to return a problem details response that is appropriate for the exception that occurred. For example:
 
@@ -67,4 +67,31 @@ public async Task Greet(string? name = null, CancellationToken cancellationToken
         return this.CreateServerErrorProblemDetailsResponse(e);
     }
 }
+```
+
+
+## Handling Exceptions in the OWIN Pipeline
+
+It is also possible to generate problem details responses from unhandled exceptions in the OWIN pipeline. To do this, you can assign a callback function to the `ExceptionHandler` property on the `ProblemDetailsMiddlewareOptions` class:
+
+```csharp
+public void Configuration(IAppBuilder app) {
+    // We only want to return a problem details response on API routes.
+    app.UseProblemDetails(new ProblemDetailsMiddlewareOptions() {
+        IncludePaths = new [] {
+            new PathString("/api")
+        },
+        ExceptionHandler = ProblemDetailsErrorHandler
+    });
+}
+
+
+private static ProblemDetails? ProblemDetailsErrorHandler(IOwinContext context, Exception error, ProblemDetailsFactory factory) {
+    if (error is System.Security.SecurityException) {
+        return factory.CreateProblemDetails(context, 403);
+    }
+
+    return null;
+}
+
 ```


### PR DESCRIPTION
Allows handling of exceptions and generation of problem details responses directly in the OWIN middleware (see #1).

`ProblemDetailsMiddlewareOptions` has a new `ExceptionHandler` property, which is a delegate that is invoked when an exception bubbles up from the OWIN pipeline. The delegate can choose to generate a problem details object that will be returned. If no problem details object is generated, the exception is rethrown.