### PR TITLE
Allow Web API exceptions to be handled by OWIN pipeline

### DIFF
--- a/ProblemDetails.WebApi.Sample/Startup.cs
+++ b/ProblemDetails.WebApi.Sample/Startup.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Intelligent Plant Ltd. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Threading.Tasks;
 using System.Web.Http;
 
 using Microsoft.Owin;
@@ -10,14 +12,57 @@ using Owin;
 namespace ProblemDetails.WebApi.Sample {
     public class Startup {
         public void Configuration(IAppBuilder app) {
+            app.UseProblemDetails(new IntelligentPlant.ProblemDetails.Owin.ProblemDetailsMiddlewareOptions() { 
+                IncludePaths = new[] { new PathString("/") },
+                ExceptionHandler = (context, error, factory) => { 
+                    if (error is HttpResponseException httpError) {
+                        return factory.CreateProblemDetails(context, (int) httpError.Response.StatusCode, detail: httpError.Message);
+                    }
+                    if (error is System.Security.SecurityException) {
+                        return factory.CreateProblemDetails(context, 403);
+                    }
+                    if (error is ArgumentException) {
+                        return factory.CreateProblemDetails(context, 400, detail: error.Message);
+                    }
+                    if (error is OperationCanceledException) {
+                        return factory.CreateProblemDetails(context, 0, detail: error.Message);
+                    }
+
+                    return factory.CreateServerErrorProblemDetails(context, error, detail: $"[OWIN PIPELINE] {error.Message}");
+                }
+            });
+
             var config = new HttpConfiguration();
             config.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
-            config.AddProblemDetails();
+            // Specify true below to handle exceptions in the Web API pipeline and false to handle 
+            // exceptions in the OWIN pipeline.
+            config.AddProblemDetails(handleExceptions: false);
             config.MapHttpAttributeRoutes();
 
             app.UseWebApi(config);
 
-            app.UseProblemDetails(new PathString("/"));
+            // Additional OWIN routes for testing the OWIN pipeline error handling.
+            app.Map("/owin", owinPipeline => {
+                owinPipeline.Use((ctx, next) => {
+                    // /owin/forbidden
+                    if (ctx.Request.Path.Equals(new PathString("/forbidden"))) {
+                        throw new System.Security.SecurityException();
+                    }
+
+                    // /owin/invalid-argument
+                    if (ctx.Request.Path.Equals(new PathString("/invalid-argument"))) {
+                        throw new ArgumentException();
+                    }
+
+                    // /owin/cancelled
+                    if (ctx.Request.Path.Equals(new PathString("/cancelled"))) {
+                        throw new OperationCanceledException();
+                    }
+
+                    ctx.Response.StatusCode = 404;
+                    return Task.CompletedTask;
+                });
+            });
         }
     }
 }

--- a/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
+++ b/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45;net46</TargetFrameworks>
     <AssemblyName>IntelligentPlant.ProblemDetails.WebApi</AssemblyName>
     <RootNamespace>IntelligentPlant.ProblemDetails</RootNamespace>
     <LangVersion>8.0</LangVersion>

--- a/ProblemDetails.WebApi/WebApi/ProblemDetailsActionFilterAttribute.cs
+++ b/ProblemDetails.WebApi/WebApi/ProblemDetailsActionFilterAttribute.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Intelligent Plant Ltd. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Net;
 using System.Net.Http;
-using System.Net.Http.Formatting;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;

--- a/ProblemDetails.WebApi/WebApi/ProblemDetailsErrorFilterAttribute.cs
+++ b/ProblemDetails.WebApi/WebApi/ProblemDetailsErrorFilterAttribute.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Intelligent Plant Ltd. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Formatting;
 using System.Web.Http;
 using System.Web.Http.Controllers;
 using System.Web.Http.Filters;

--- a/ProblemDetails.WebApi/WebApi/ProblemDetailsHttpConfigurationExtensions.cs
+++ b/ProblemDetails.WebApi/WebApi/ProblemDetailsHttpConfigurationExtensions.cs
@@ -17,15 +17,38 @@ namespace System.Web.Http {
         /// <param name="httpConfiguration">
         ///   The <see cref="HttpConfiguration"/>.
         /// </param>
+        /// <param name="handleExceptions">
+        /// 
+        /// <para>
+        ///   Specifies if the Web API pipeline should handle exceptions. When <see langword="true"/>, 
+        ///   a <see cref="ProblemDetailsErrorFilterAttribute"/> filter will be added to the global 
+        ///   Web API configuration. When <see langword="false"/>, the default <see cref="ExceptionHandling.IExceptionHandler"/> 
+        ///   service for the Web API pipeline will be replaced with a <see cref="RethrowErrorExceptionHandler"/>, 
+        ///   which will cause all unhandled Web API exceptions to propagate to the web host's pipeline.
+        /// </para>
+        /// 
+        /// <para>
+        ///   You should specify <see langword="false"/> here if you intend to generate problem 
+        ///   details responses for errors in the OWIN pipeline (via e.g. the 
+        ///   <see cref="IntelligentPlant.ProblemDetails.Owin.ProblemDetailsMiddlewareOptions.ExceptionHandler"/> 
+        ///   property) instead of in the Web API pipeline.
+        /// </para>
+        /// 
+        /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="httpConfiguration"/> is <see langword="null"/>.
         /// </exception>
-        public static void AddProblemDetails(this HttpConfiguration httpConfiguration) {
+        public static void AddProblemDetails(this HttpConfiguration httpConfiguration, bool handleExceptions = true) {
             if (httpConfiguration == null) {
                 throw new ArgumentNullException(nameof(httpConfiguration));
             }
 
-            httpConfiguration.Filters.Add(new ProblemDetailsErrorFilterAttribute());
+            if (handleExceptions) {
+                httpConfiguration.Filters.Add(new ProblemDetailsErrorFilterAttribute());
+            }
+            else {
+                httpConfiguration.Services.Replace(typeof(ExceptionHandling.IExceptionHandler), new RethrowErrorExceptionHandler());
+            }
             httpConfiguration.Filters.Add(new ProblemDetailsActionFilterAttribute());
         }
 

--- a/ProblemDetails.WebApi/WebApi/RethrowErrorExceptionHandler.cs
+++ b/ProblemDetails.WebApi/WebApi/RethrowErrorExceptionHandler.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Intelligent Plant Ltd. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http.ExceptionHandling;
+
+namespace IntelligentPlant.ProblemDetails.WebApi {
+
+    /// <summary>
+    /// <see cref="IExceptionHandler"/> class that intentionally leaves exceptions unhandled so 
+    /// that they can be handled by the host application's request pipeline instead.
+    /// </summary>
+    public class RethrowErrorExceptionHandler : IExceptionHandler {
+
+        /// <summary>
+        /// Completed task.
+        /// </summary>
+        private static readonly Task s_completedTask =
+#if NET45
+            Task.FromResult(0);
+#else
+            Task.CompletedTask;
+#endif
+
+        /// <inheritdoc/>
+        public Task HandleAsync(ExceptionHandlerContext context, CancellationToken cancellationToken) {
+            context.Result = null;
+            return s_completedTask;
+        }
+    }
+}


### PR DESCRIPTION
These changes allow the default catch-all `IExceptionHandler` service in the Web API configuration to be replaced with one that will cause all unhandled exceptions to bubble up from the Web API pipeline into the host app's request pipeline.

This allows all exceptions to be handled in the OWIN pipeline instead of in the Web API pipeline.