### PR TITLE
Custom factories

### DIFF
--- a/ProblemDetails.WebApi.Sample/Startup.cs
+++ b/ProblemDetails.WebApi.Sample/Startup.cs
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Threading.Tasks;
 using System.Web.Http;
+using System.Web.Http.ModelBinding;
 
 using Microsoft.Owin;
 
@@ -12,9 +15,12 @@ using Owin;
 namespace ProblemDetails.WebApi.Sample {
     public class Startup {
         public void Configuration(IAppBuilder app) {
-            app.UseProblemDetails(new IntelligentPlant.ProblemDetails.Owin.ProblemDetailsMiddlewareOptions() { 
+            var customFactory = new CustomProblemDetailsFactory();
+
+            app.UseProblemDetails(new IntelligentPlant.ProblemDetails.Owin.ProblemDetailsMiddlewareOptions() {
                 IncludePaths = new[] { new PathString("/") },
-                ExceptionHandler = (context, error, factory) => { 
+                Factory = customFactory,
+                ExceptionHandler = (context, error, factory) => {
                     if (error is HttpResponseException httpError) {
                         return factory.CreateProblemDetails(context, (int) httpError.Response.StatusCode, detail: httpError.Message);
                     }
@@ -28,7 +34,7 @@ namespace ProblemDetails.WebApi.Sample {
                         return factory.CreateProblemDetails(context, 0, detail: error.Message);
                     }
 
-                    return factory.CreateServerErrorProblemDetails(context, error, detail: $"[OWIN PIPELINE] {error.Message}");
+                    return factory.CreateServerErrorProblemDetails(context, error, detail: error.Message);
                 }
             });
 
@@ -36,7 +42,7 @@ namespace ProblemDetails.WebApi.Sample {
             config.IncludeErrorDetailPolicy = IncludeErrorDetailPolicy.Always;
             // Specify true below to handle exceptions in the Web API pipeline and false to handle 
             // exceptions in the OWIN pipeline.
-            config.AddProblemDetails(handleExceptions: false);
+            config.AddProblemDetails(handleExceptions: true, factory: customFactory);
             config.MapHttpAttributeRoutes();
 
             app.UseWebApi(config);
@@ -63,6 +69,50 @@ namespace ProblemDetails.WebApi.Sample {
                     return Task.CompletedTask;
                 });
             });
+        }
+
+        private class CustomProblemDetailsFactory : IntelligentPlant.ProblemDetails.DefaultProblemDetailsFactory {
+
+            private static void AddCustomProperties(IntelligentPlant.ProblemDetails.ProblemDetails problemDetails) {
+                problemDetails.Extensions["request-id"] = "some-id";
+                problemDetails.Extensions["utc-time"] = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ");
+            }
+
+
+            public override IntelligentPlant.ProblemDetails.ProblemDetails CreateProblemDetails(IOwinContext httpContext, int? statusCode = null, string title = null, string type = null, string detail = null, string instance = null) {
+                var result = base.CreateProblemDetails(httpContext, statusCode, title, type, detail, instance);
+                AddCustomProperties(result);
+                return result;
+            }
+
+
+            public override IntelligentPlant.ProblemDetails.ServerErrorProblemDetails CreateServerErrorProblemDetails(IOwinContext httpContext, Exception error = null, int? statusCode = null, string title = null, string type = null, string detail = null, string instance = null) {
+                var result = base.CreateServerErrorProblemDetails(httpContext, error, statusCode, title, type, detail, instance);
+                AddCustomProperties(result);
+                return result;
+            }
+
+
+            public override IntelligentPlant.ProblemDetails.ValidationProblemDetails CreateValidationProblemDetails(IOwinContext httpContext, IEnumerable<ValidationResult> errors, int? statusCode = null, string title = null, string type = null, string detail = null, string instance = null) {
+                var result = base.CreateValidationProblemDetails(httpContext, errors, statusCode, title, type, detail, instance);
+                AddCustomProperties(result);
+                return result;
+            }
+
+
+            public override IntelligentPlant.ProblemDetails.ValidationProblemDetails CreateValidationProblemDetails(IOwinContext httpContext, ModelStateDictionary modelStateDictionary, int? statusCode = null, string title = null, string type = null, string detail = null, string instance = null) {
+                var result = base.CreateValidationProblemDetails(httpContext, modelStateDictionary, statusCode, title, type, detail, instance);
+                AddCustomProperties(result);
+                return result;
+            }
+
+
+            public override IntelligentPlant.ProblemDetails.ValidationProblemDetails CreateValidationProblemDetails(IOwinContext httpContext, ValidationException error, int? statusCode = null, string title = null, string type = null, string detail = null, string instance = null) {
+                var result = base.CreateValidationProblemDetails(httpContext, error, statusCode, title, type, detail, instance);
+                AddCustomProperties(result);
+                return result;
+            }
+
         }
     }
 }

--- a/ProblemDetails.WebApi/DefaultProblemDetailsFactory.cs
+++ b/ProblemDetails.WebApi/DefaultProblemDetailsFactory.cs
@@ -14,7 +14,7 @@ namespace IntelligentPlant.ProblemDetails {
     /// <summary>
     /// Default <see cref="ProblemDetailsFactory"/> implementation.
     /// </summary>
-    internal sealed class DefaultProblemDetailsFactory : ProblemDetailsFactory {
+    public class DefaultProblemDetailsFactory : ProblemDetailsFactory {
 
         /// <inheritdoc/>
         public override ProblemDetails CreateProblemDetails(

--- a/ProblemDetails.WebApi/Owin/ProblemDetailsMiddlewareOptions.cs
+++ b/ProblemDetails.WebApi/Owin/ProblemDetailsMiddlewareOptions.cs
@@ -23,6 +23,12 @@ namespace IntelligentPlant.ProblemDetails.Owin {
         public IEnumerable<PathString>? ExcludePaths { get; set; }
 
         /// <summary>
+        /// The <see cref="ProblemDetailsFactory"/> to use to create problem details objects. 
+        /// Specify <see langword="null"/> to use <see cref="ProblemDetailsFactory.Default"/>.
+        /// </summary>
+        public ProblemDetailsFactory? Factory { get; set; }
+
+        /// <summary>
         /// A delegate that can be used to generate a custom <see cref="ProblemDetails"/> object 
         /// for an unhandled exception in the OWIN pipeline. Return <see langword="null"/> to 
         /// rethrow the unhandled exception.

--- a/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
+++ b/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/intelligentplant/ProblemDetails.WebApi</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
   </PropertyGroup>
 
   <Choose>

--- a/ProblemDetails.WebApi/WebApi/ProblemDetailsActionFilterAttribute.cs
+++ b/ProblemDetails.WebApi/WebApi/ProblemDetailsActionFilterAttribute.cs
@@ -17,7 +17,19 @@ namespace IntelligentPlant.ProblemDetails.WebApi {
         /// <summary>
         /// The <see cref="ProblemDetailsFactory"/> to use.
         /// </summary>
-        private readonly ProblemDetailsFactory _factory = ProblemDetailsFactory.Default;
+        private readonly ProblemDetailsFactory _factory;
+
+
+        /// <summary>
+        /// Creates a new <see cref="ProblemDetailsActionFilterAttribute"/> instance.
+        /// </summary>
+        /// <param name="factory">
+        ///   The <see cref="ProblemDetailsFactory"/> to use. Specify <see langword="null"/> to 
+        ///   use <see cref="ProblemDetailsFactory.Default"/>.
+        /// </param>
+        public ProblemDetailsActionFilterAttribute(ProblemDetailsFactory? factory = null) {
+            _factory = factory ?? ProblemDetailsFactory.Default;
+        }
 
 
         /// <inheritdoc/>

--- a/ProblemDetails.WebApi/WebApi/ProblemDetailsErrorFilterAttribute.cs
+++ b/ProblemDetails.WebApi/WebApi/ProblemDetailsErrorFilterAttribute.cs
@@ -21,7 +21,19 @@ namespace IntelligentPlant.ProblemDetails.WebApi {
         /// <summary>
         /// The <see cref="ProblemDetailsFactory"/> to use.
         /// </summary>
-        private readonly ProblemDetailsFactory _factory = ProblemDetailsFactory.Default;
+        private readonly ProblemDetailsFactory _factory;
+
+
+        /// <summary>
+        /// Creates a new <see cref="ProblemDetailsErrorFilterAttribute"/> instance.
+        /// </summary>
+        /// <param name="factory">
+        ///   The <see cref="ProblemDetailsFactory"/> to use. Specify <see langword="null"/> to 
+        ///   use <see cref="ProblemDetailsFactory.Default"/>.
+        /// </param>
+        public ProblemDetailsErrorFilterAttribute(ProblemDetailsFactory? factory = null) {
+            _factory = factory ?? ProblemDetailsFactory.Default;
+        }
 
 
         /// <inheritdoc/>

--- a/ProblemDetails.WebApi/WebApi/ProblemDetailsHttpConfigurationExtensions.cs
+++ b/ProblemDetails.WebApi/WebApi/ProblemDetailsHttpConfigurationExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Intelligent Plant Ltd. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using IntelligentPlant.ProblemDetails;
 using IntelligentPlant.ProblemDetails.WebApi;
 
 namespace System.Web.Http {
@@ -35,21 +36,25 @@ namespace System.Web.Http {
         /// </para>
         /// 
         /// </param>
+        /// <param name="factory">
+        ///   The <see cref="ProblemDetailsFactory"/> to use. Specify <see langword="null"/> to 
+        ///   use <see cref="ProblemDetailsFactory.Default"/>.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="httpConfiguration"/> is <see langword="null"/>.
         /// </exception>
-        public static void AddProblemDetails(this HttpConfiguration httpConfiguration, bool handleExceptions = true) {
+        public static void AddProblemDetails(this HttpConfiguration httpConfiguration, bool handleExceptions = true, ProblemDetailsFactory? factory = null) {
             if (httpConfiguration == null) {
                 throw new ArgumentNullException(nameof(httpConfiguration));
             }
 
             if (handleExceptions) {
-                httpConfiguration.Filters.Add(new ProblemDetailsErrorFilterAttribute());
+                httpConfiguration.Filters.Add(new ProblemDetailsErrorFilterAttribute(factory));
             }
             else {
                 httpConfiguration.Services.Replace(typeof(ExceptionHandling.IExceptionHandler), new RethrowErrorExceptionHandler());
             }
-            httpConfiguration.Filters.Add(new ProblemDetailsActionFilterAttribute());
+            httpConfiguration.Filters.Add(new ProblemDetailsActionFilterAttribute(factory));
         }
 
     }


### PR DESCRIPTION
Adds hooks to pass a `ProblemDetailsFactory` instance when configuring the OWIN middleware or adding the Web API registration. This allows e.g. adding custom properties to all outgoing problem details objects (via the problem detail's `Extensions` dictionary).