### PR TITLE
Fix Status Code Bug

### DIFF
--- a/ProblemDetails.WebApi.Sample/Controllers/ExampleController.cs
+++ b/ProblemDetails.WebApi.Sample/Controllers/ExampleController.cs
@@ -60,7 +60,7 @@ namespace ProblemDetails.WebApi.Sample.Controllers {
         [HttpGet]
         [Route("create-direct")]
         public IHttpActionResult CreateDirect() {
-            return this.CreateProblemDetailsResponse(HttpStatusCode.BadRequest, detail: "Problem details was directly created");
+            return this.CreateProblemDetailsResponse(HttpStatusCode.Forbidden, detail: "Problem details was directly created");
         }
 
 

--- a/ProblemDetails.WebApi/Owin/ProblemDetailsMiddleware.cs
+++ b/ProblemDetails.WebApi/Owin/ProblemDetailsMiddleware.cs
@@ -93,9 +93,6 @@ namespace IntelligentPlant.ProblemDetails.Owin {
                         throw;
                     }
 
-                    if (errorDetails.Status.HasValue) {
-                        response.StatusCode = errorDetails.Status.Value;
-                    };
                     await WriteProblemDetailsToStream(errorDetails, response, responseBodyStream).ConfigureAwait(false);
                 }
                 finally {
@@ -129,6 +126,12 @@ namespace IntelligentPlant.ProblemDetails.Owin {
         ///   A <see cref="Task"/> that will perform the write.
         /// </returns>
         private async Task WriteProblemDetailsToStream(ProblemDetails problemDetails, IOwinResponse response, Stream stream) {
+            // Set response status code
+            if (problemDetails.Status.HasValue)
+            {
+                response.StatusCode = problemDetails.Status.Value;
+            };
+
             // Create a new buffer, and then create and serialize a problem details object 
             // into the new buffer.
             using (var ms = new MemoryStream()) {

--- a/ProblemDetails.WebApi/WebApi/ApiControllerExtensions.cs
+++ b/ProblemDetails.WebApi/WebApi/ApiControllerExtensions.cs
@@ -513,7 +513,7 @@ namespace IntelligentPlant.ProblemDetails.WebApi {
                 detail
             );
             var response = request.CreateResponse(
-                HttpStatusCode.BadRequest, 
+                statusCode,
                 problemDetails,
                 new JsonMediaTypeFormatter(),
                 ClientErrorDataDefaults.MediaType


### PR DESCRIPTION
Fixed issue that prevented the CreateProblemDetailsResponse from returning the given status code.

Ensured middleware uses status code set in the ProblemDetailsFactory.

Updated Example controller to use a status code other than the one that was hard-coded for testing