### PR TITLE
Separate models

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,41 @@
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <Authors>Intelligent Plant</Authors>
+    <Company>Intelligent Plant Ltd.</Company>
+    <PackageProjectUrl>https://github.com/intelligentplant/ProblemDetails.WebApi</PackageProjectUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <NeutralLanguage>en</NeutralLanguage>
+    <Version>3.0.0</Version>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition=" $([System.DateTime]::UtcNow.Year) &gt; 2020 ">
+      <PropertyGroup>
+        <Copyright>Copyright © 2020-$([System.DateTime]::UtcNow.Year) $(Company)</Copyright>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <Copyright>Copyright © 2020 $(Company)</Copyright>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  
+</Project>

--- a/ProblemDetails.Core/ProblemDetails.Core.csproj
+++ b/ProblemDetails.Core/ProblemDetails.Core.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net45;net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>IntelligentPlant.ProblemDetails.Core</AssemblyName>
     <RootNamespace>IntelligentPlant.ProblemDetails</RootNamespace>
     <PackageId>IntelligentPlant.ProblemDetails.Core</PackageId>
+    <Description>Core types for RFC 7807 problem details.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProblemDetails.Core/ProblemDetails.Core.csproj
+++ b/ProblemDetails.Core/ProblemDetails.Core.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net45;net46;netstandard2.0</TargetFrameworks>
+    <AssemblyName>IntelligentPlant.ProblemDetails.Core</AssemblyName>
+    <RootNamespace>IntelligentPlant.ProblemDetails</RootNamespace>
+    <PackageId>IntelligentPlant.ProblemDetails.Core</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/ProblemDetails.Core/ProblemDetails.Core.csproj
+++ b/ProblemDetails.Core/ProblemDetails.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <AssemblyName>IntelligentPlant.ProblemDetails.Core</AssemblyName>
     <RootNamespace>IntelligentPlant.ProblemDetails</RootNamespace>
     <PackageId>IntelligentPlant.ProblemDetails.Core</PackageId>

--- a/ProblemDetails.Core/ProblemDetails.cs
+++ b/ProblemDetails.Core/ProblemDetails.cs
@@ -17,7 +17,7 @@ namespace IntelligentPlant.ProblemDetails {
         /// <summary>
         /// A URI reference [RFC3986] that identifies the problem type. This specification encourages that, when
         /// dereferenced, it provide human-readable documentation for the problem type
-        /// (e.g., using HTML [W3C.REC-html5-20141028]).  When this member is not present, its value is assumed to be
+        /// (e.g., using HTML [W3C.REC-html5-20141028]). When this member is not present, its value is assumed to be
         /// "about:blank".
         /// </summary>
         [JsonProperty("type")]
@@ -57,7 +57,7 @@ namespace IntelligentPlant.ProblemDetails {
         /// </para>
         /// </summary>
         /// <remarks>
-        /// The round-tripping behavior for <see cref="Extensions"/> is determined by the implementation of the Input \ Output formatters.
+        /// The round-tripping behavior for <see cref="Extensions"/> is determined by the implementation of the Input / Output formatters.
         /// In particular, complex types or collection types may not round-trip to the original type when using the built-in JSON or XML formatters.
         /// </remarks>
         [JsonExtensionData]

--- a/ProblemDetails.WebApi.sln
+++ b/ProblemDetails.WebApi.sln
@@ -9,9 +9,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProblemDetails.WebApi.Sampl
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "common", "common", "{3FCAAA94-1AB9-461C-9D24-CC0E728CB83A}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
 		LICENSE.txt = LICENSE.txt
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProblemDetails.Core", "ProblemDetails.Core\ProblemDetails.Core.csproj", "{5FD75CEA-E79F-4885-A7D2-1854E14CA12B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +30,10 @@ Global
 		{31B300F6-DB14-433A-810B-2B3E3BF7427F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{31B300F6-DB14-433A-810B-2B3E3BF7427F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{31B300F6-DB14-433A-810B-2B3E3BF7427F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FD75CEA-E79F-4885-A7D2-1854E14CA12B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FD75CEA-E79F-4885-A7D2-1854E14CA12B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FD75CEA-E79F-4885-A7D2-1854E14CA12B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FD75CEA-E79F-4885-A7D2-1854E14CA12B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
+++ b/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>IntelligentPlant.ProblemDetails.WebApi</AssemblyName>
     <RootNamespace>IntelligentPlant.ProblemDetails</RootNamespace>
     <PackageId>IntelligentPlant.ProblemDetails.WebApi</PackageId>
+    <Description>Web API 2/OWIN support for RFC 7807 problem details.</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
+++ b/ProblemDetails.WebApi/ProblemDetails.WebApi.csproj
@@ -4,45 +4,17 @@
     <TargetFrameworks>net45;net46</TargetFrameworks>
     <AssemblyName>IntelligentPlant.ProblemDetails.WebApi</AssemblyName>
     <RootNamespace>IntelligentPlant.ProblemDetails</RootNamespace>
-    <LangVersion>8.0</LangVersion>
-    <Nullable>enable</Nullable>
-    <Authors>Intelligent Plant</Authors>
-    <Company>Intelligent Plant Ltd.</Company>
     <PackageId>IntelligentPlant.ProblemDetails.WebApi</PackageId>
-    <PackageProjectUrl>https://github.com/intelligentplant/ProblemDetails.WebApi</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <NeutralLanguage>en</NeutralLanguage>
-    <Version>2.2.0</Version>
-  </PropertyGroup>
-
-  <Choose>
-    <When Condition=" $([System.DateTime]::UtcNow.Year) &gt; 2020 ">
-      <PropertyGroup>
-        <Copyright>Copyright © 2020-$([System.DateTime]::UtcNow.Year) $(Company)</Copyright>
-      </PropertyGroup>
-    </When>
-    <Otherwise>
-      <PropertyGroup>
-        <Copyright>Copyright © 2020 $(Company)</Copyright>
-      </PropertyGroup>
-    </Otherwise>
-  </Choose>
-
-  <PropertyGroup>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Owin" Version="5.2.7" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProblemDetails.Core\ProblemDetails.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Moves the core `ProblemDetails` type into a new project/package, for easier consumption by C# clients.